### PR TITLE
fix: remove address param

### DIFF
--- a/zap/contracts/y3CrvZapper.vy
+++ b/zap/contracts/y3CrvZapper.vy
@@ -9,7 +9,7 @@ interface Vault:
 
 interface Claimable:
     def claimFor(recipient: address): nonpayable
-    def claim(recipient: address): nonpayable
+    def claim(): nonpayable
 
 threeCrv: public(ERC20)
 threeCrvVault: public(Vault)


### PR DESCRIPTION
Removed the address parameter of the `claim` function of the `Claimable` interface.